### PR TITLE
Ignore .lock files

### DIFF
--- a/schemas/org.gnome.shell.extensions.rclone-manager.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.rclone-manager.gschema.xml
@@ -27,7 +27,7 @@
     </key>
 
     <key name="prefkey003-ignore-patterns" type="s">
-      <default>'\\.remmina\\.,~lock,\\.tmp,\\.log,\\.Trash-1000'</default>
+      <default>'\\.remmina\\.,~lock,\\.tmp,\\.log,\\.Trash-1000,\\.lock'</default>
       <summary>Filenames to be ignored</summary>
       <description>
         Comma separed filenames to be ignored by inotify


### PR DESCRIPTION
The "git fetch" command creates maintenance.lock files which triggers errors in this extension when using watch mode.
Ignoring .lock files in the presets will prevent others from running into this issue.